### PR TITLE
Feature/5 process resolve transactions

### DIFF
--- a/sample-tx.csv
+++ b/sample-tx.csv
@@ -7,3 +7,4 @@ withdrawal,1,4,1.5
 withdrawal,2,5,3.0
 withdrawal,1,5,0.3565
 dispute,1,1,0
+resolve,1,1,0

--- a/src/acct/account.rs
+++ b/src/acct/account.rs
@@ -35,16 +35,23 @@ impl Account {
     }
 
     pub fn withdraw(&mut self, tranx: &Transaction) {
-        if tranx.amount < self.available {
+        if tranx.amount <= self.available {
             self.available -= tranx.amount;
             self.total -= tranx.amount;
         }
     }
 
     pub fn dispute(&mut self, tranx: &Transaction) {
-        if tranx.amount < self.available {
+        if tranx.amount <= self.available {
             self.available -= tranx.amount;
             self.held += tranx.amount;
+        }
+    }
+
+    pub fn resolve(&mut self, tranx: &Transaction) {
+        if tranx.amount <= self.held {
+            self.available += tranx.amount;
+            self.held -= tranx.amount;
         }
     }
 }

--- a/src/acct/account.rs
+++ b/src/acct/account.rs
@@ -2,6 +2,7 @@ use std::io;
 extern crate csv;
 
 use crate::acct::storage;
+use crate::tx::transaction::Dispute;
 use crate::tx::{storage as TxStore, transaction::Transaction};
 use serde::Serialize;
 
@@ -168,6 +169,14 @@ pub fn process_dispute(tranx: &Transaction) {
             .lock()
             .unwrap()
             .read(tranx.tx, |trx| trx.unwrap().clone());
+
+        let dispute = Dispute::new(tranx.client, tranx.tx, false);
+
+        // Store dispute
+        TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .insert_dispute(dispute);
     }
 
     let account_exists: bool;

--- a/src/acct/account.rs
+++ b/src/acct/account.rs
@@ -221,6 +221,95 @@ pub fn process_dispute(tranx: &Transaction) {
     }
 }
 
+pub fn process_resolve(tranx: &Transaction) {
+    if tranx.r#type != "resolve" {
+        return;
+    }
+
+    let tx_exists: bool;
+    let dispute_exists: bool;
+
+    unsafe {
+        tx_exists = TxStore::TRANSACTIONS.lock().unwrap().exists(tranx.tx);
+        dispute_exists = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute_exists(tranx.tx);
+    }
+
+    if !tx_exists || !dispute_exists {
+        return;
+    }
+
+    let stored_tranx: Transaction;
+    let stored_dispute: Dispute;
+
+    unsafe {
+        stored_tranx = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .read(tranx.tx, |trx| trx.unwrap().clone());
+
+        stored_dispute = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute(tranx.tx, |trx| trx.unwrap().clone());
+    }
+
+    if stored_dispute.resolved {
+        return;
+    }
+
+    let account_exists: bool;
+
+    unsafe {
+        account_exists = storage::ACCOUNTS.lock().unwrap().exists(tranx.client);
+    }
+
+    if !account_exists {
+        let new_account = Account::new(tranx.client, 0.0, 0.0);
+        unsafe {
+            storage::ACCOUNTS.lock().unwrap().insert(new_account);
+        }
+    }
+
+    let u_account: Option<Account>;
+
+    unsafe {
+        let updated_dispute =
+            TxStore::TRANSACTIONS
+                .lock()
+                .unwrap()
+                .modify_dispute(stored_dispute.tx, |dis| {
+                    let disp = dis.unwrap();
+                    disp.resolved = true;
+
+                    return *disp;
+                });
+
+        u_account = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .modify(tranx.client, |acct| {
+                let a = if let Some(acc) = acct {
+                    acc.resolve(&stored_tranx);
+                    Some(*acc)
+                } else {
+                    None
+                };
+                return a;
+            });
+
+        if let Some(acct) = u_account {
+            storage::ACCOUNTS.lock().unwrap().insert(acct);
+            TxStore::TRANSACTIONS
+                .lock()
+                .unwrap()
+                .insert_dispute(updated_dispute);
+        }
+    }
+}
+
 fn insert_transaction(tranx: &Transaction) {
     let tx_exists: bool;
 

--- a/src/acct/storage.rs
+++ b/src/acct/storage.rs
@@ -40,7 +40,7 @@ impl AccountStorage {
             .accounts
             .lock()
             .unwrap()
-            .insert(account.client, account.clone());
+            .insert(account.client, account);
 
         if let Some(_acct) = acc {
             return true;
@@ -68,7 +68,7 @@ impl AccountStorage {
 /// Tests
 
 #[test]
-fn test_insert() {
+fn test_account_storage_insert() {
     let account = Account {
         client: 1,
         available: 20.0,
@@ -93,10 +93,7 @@ fn test_insert() {
 }
 
 #[test]
-fn test_modify() {
-    unsafe {
-        ACCOUNTS.lock().unwrap().clear();
-    }
+fn test_account_storage_modify() {
     let account = Account {
         client: 1,
         available: 20.0,
@@ -122,15 +119,15 @@ fn test_modify() {
         let a = acc.unwrap();
         a.available = 25.0;
 
-        db.insert(*a);
-
         return *a;
     });
 
+    db.insert(updated);
+
     assert!(
-        updated.available == account.available,
+        updated.available == 25.0,
         "account not equal after modification; expect {}, got {}",
-        account.available,
+        25.0,
         updated.available,
     );
 }

--- a/src/acct/storage.rs
+++ b/src/acct/storage.rs
@@ -84,7 +84,7 @@ fn test_insert() {
     db.insert(account.clone());
 
     let acct: Account = db.read(1, |acct| acct.unwrap().clone());
-    println!("{:?}", acct);
+    // println!("{:?}", acct);
 
     assert!(
         acct.client == account.client,

--- a/src/acct/tests.rs
+++ b/src/acct/tests.rs
@@ -223,7 +223,132 @@ fn test_process_dispute() {
 }
 
 #[test]
-fn test_deposit() {
+fn test_process_resolve() {
+    let tranx_dispute = Transaction::new("dispute".to_string(), 4, 44, 0.0);
+    let tranx_resolve = Transaction::new("resolve".to_string(), 4, 44, 0.0);
+
+    let tranx_deposit = Transaction::new("deposit".to_string(), 4, 4, 15.0);
+    let tranx_deposit_2 = Transaction::new("deposit".to_string(), 4, 44, 10.0);
+
+    account::process_resolve(&tranx_resolve);
+
+    unsafe {
+        storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx_dispute.client, |acc| {
+                assert!(
+                    acc == None,
+                    "invalid available funds; expected {}, got {:?}",
+                    "None",
+                    acc
+                );
+            });
+    }
+
+    account::process_deposit(&tranx_deposit);
+    account::process_deposit(&tranx_deposit_2);
+    account::process_dispute(&tranx_dispute);
+
+    unsafe {
+        let acct = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx_dispute.client, |acc| acc.unwrap().clone());
+        assert!(
+            acct.available == tranx_deposit.amount,
+            "invalid available funds; expected {}, got {}",
+            tranx_deposit.amount,
+            acct.available
+        );
+
+        assert!(
+            acct.held == tranx_deposit_2.amount,
+            "invalid held funds; expected {}, got {}",
+            tranx_deposit_2.amount,
+            acct.held
+        );
+
+        let dispute = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute(tranx_dispute.tx, |acc| acc.unwrap().clone());
+
+        assert!(
+            dispute.tx == tranx_dispute.tx,
+            "invalid dispute tx; expected {}, got {}",
+            tranx_dispute.tx,
+            dispute.tx
+        );
+
+        assert!(
+            dispute.client == tranx_dispute.client,
+            "invalid dispute client; expected {}, got {}",
+            tranx_dispute.client,
+            dispute.client
+        );
+
+        assert!(
+            dispute.resolved == false,
+            "invalid dispute client; expected {}, got {}",
+            false,
+            dispute.resolved
+        );
+    }
+    // test resolve
+    account::process_resolve(&tranx_resolve);
+
+    unsafe {
+        let acct = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx_dispute.client, |acc| acc.unwrap().clone());
+
+        let available = tranx_deposit.amount + tranx_deposit_2.amount;
+        assert!(
+            acct.available == available,
+            "invalid available funds; expected {}, got {}",
+            available,
+            acct.available
+        );
+
+        assert!(
+            acct.held == 0.0,
+            "invalid held funds; expected {}, got {}",
+            0.0,
+            acct.held
+        );
+
+        let dispute = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute(tranx_dispute.tx, |acc| acc.unwrap().clone());
+
+        assert!(
+            dispute.tx == tranx_dispute.tx,
+            "invalid dispute tx; expected {}, got {}",
+            tranx_dispute.tx,
+            dispute.tx
+        );
+
+        assert!(
+            dispute.client == tranx_dispute.client,
+            "invalid dispute client; expected {}, got {}",
+            tranx_dispute.client,
+            dispute.client
+        );
+
+        assert!(
+            dispute.resolved == true,
+            "invalid dispute client; expected {}, got {}",
+            true,
+            dispute.resolved
+        );
+    }
+}
+
+#[test]
+fn test_account_deposit() {
     let mut account = Account::new(1, 20.0, 0.0);
     let tranx = Transaction {
         r#type: "deposit".to_string(),
@@ -266,7 +391,7 @@ fn test_deposit() {
 }
 
 #[test]
-fn test_withdraw() {
+fn test_account_withdraw() {
     let mut account = Account::new(1, 20.0, 0.0);
     let mut tranx = Transaction {
         r#type: "deposit".to_string(),
@@ -331,7 +456,7 @@ fn test_withdraw() {
 }
 
 #[test]
-fn test_dispute() {
+fn test_account_dispute() {
     let mut account = Account::new(1, 20.0, 0.0);
     let mut tranx = Transaction {
         r#type: "dispute".to_string(),
@@ -396,7 +521,7 @@ fn test_dispute() {
 }
 
 #[test]
-fn test_resolve() {
+fn test_account_resolve() {
     let mut account = Account::new(1, 0.0, 20.0);
     let mut tranx_deposit = Transaction::new("deposit".to_string(), 1, 1, 20.0);
 

--- a/src/acct/tests.rs
+++ b/src/acct/tests.rs
@@ -214,6 +214,25 @@ fn test_process_dispute() {
             tranx_deposit_2.amount,
             acct.held
         );
+
+        let dispute = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute(tranx_dispute.tx, |acc| acc.unwrap().clone());
+
+        assert!(
+            dispute.tx == tranx_dispute.tx,
+            "invalid dispute tx; expected {}, got {}",
+            tranx_dispute.tx,
+            dispute.tx
+        );
+
+        assert!(
+            dispute.client == tranx_dispute.client,
+            "invalid dispute client; expected {}, got {}",
+            tranx_dispute.client,
+            dispute.client
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ fn read_csv_file() -> Result<(), Box<dyn Error>> {
         account::process_deposit(&record);
         account::process_withdrawal(&record);
         account::process_dispute(&record);
+        account::process_resolve(&record);
     }
 
     account::print();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,13 @@ extern crate csv;
 mod acct;
 mod tx;
 
+use std::collections::HashMap;
 use std::env;
 use std::error::Error;
 use std::ffi::OsString;
 use std::fs::File;
 use std::process;
+use std::sync::Mutex;
 
 use crate::acct::account::{self, Account};
 use crate::tx::transaction::{self, Transaction};

--- a/src/tx/storage.rs
+++ b/src/tx/storage.rs
@@ -5,19 +5,21 @@ use std::{
 
 use once_cell::sync::Lazy;
 
-use crate::tx::transaction::Transaction;
+use crate::tx::transaction::{Dispute, Transaction};
 
 pub static mut TRANSACTIONS: Lazy<Mutex<TransactionStorage>> =
     Lazy::new(|| Mutex::new(TransactionStorage::new()));
 
 pub struct TransactionStorage {
     transactions: Arc<Mutex<HashMap<u32, Transaction>>>,
+    disputes: Arc<Mutex<HashMap<u32, Dispute>>>,
 }
 
 impl TransactionStorage {
     pub fn new() -> Self {
         Self {
             transactions: Arc::new(Mutex::new(HashMap::new())),
+            disputes: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -49,6 +51,35 @@ impl TransactionStorage {
     pub fn clear(&self) {
         self.transactions.lock().unwrap().clear();
     }
+
+    pub fn dispute<F, R>(&self, id: u32, f: F) -> R
+    where
+        F: FnOnce(Option<&Dispute>) -> R,
+    {
+        f(self.disputes.lock().unwrap().get(&id))
+    }
+
+    pub fn insert_dispute(&self, dispute: Dispute) -> bool {
+        let acc = self
+            .disputes
+            .lock()
+            .unwrap()
+            .insert(dispute.tx, dispute.clone());
+
+        if let Some(_acct) = acc {
+            return true;
+        }
+
+        false
+    }
+
+    pub fn dispute_exists(&self, id: u32) -> bool {
+        self.transactions.lock().unwrap().contains_key(&id)
+    }
+
+    pub fn clear_disputes(&self) {
+        self.transactions.lock().unwrap().clear();
+    }
 }
 
 /// Tests
@@ -76,5 +107,28 @@ fn test_insert() {
     assert!(
         tranx.r#type == transaction.r#type,
         "created client id and fetched client id are not equal"
+    );
+}
+
+#[test]
+fn test_insert_dispute() {
+    unsafe {
+        TRANSACTIONS.lock().unwrap().clear_disputes();
+    }
+    let dispute = Dispute::new(1, 1, false);
+
+    let db = TransactionStorage::new();
+    let exists = db.exists(1);
+    assert!(!exists, "transaction should be empty");
+
+    db.insert_dispute(dispute.clone());
+
+    let dispx: Dispute = db.dispute(1, |acct| acct.unwrap().clone());
+
+    assert!(
+        dispx.tx == dispute.tx,
+        "created client id and fetched client id are not equal; expected {}, got {}",
+        dispute.tx,
+        dispx.tx
     );
 }

--- a/src/tx/transaction.rs
+++ b/src/tx/transaction.rs
@@ -20,3 +20,20 @@ impl Transaction {
         }
     }
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Dispute {
+    pub client: u16,
+    pub tx: u32,
+    pub resolved: bool,
+}
+
+impl Dispute {
+    pub fn new(client: u16, tx: u32, resolved: bool) -> Self {
+        Self {
+            client,
+            tx,
+            resolved,
+        }
+    }
+}

--- a/src/tx/transaction.rs
+++ b/src/tx/transaction.rs
@@ -21,7 +21,7 @@ impl Transaction {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub struct Dispute {
     pub client: u16,
     pub tx: u32,


### PR DESCRIPTION
Task:
1. Add a method that handles dispute resolution.
2. Ignore if:
 * transaction does not exist.
 * transaction is not under dispute.
 * if tx amount is greater than held funds
3. increase available and decrease held funds of the client by the amount no longer in dispute.

Commits:
* added dispute store and unit tests
* added resolve method to account and fixed failed unit tests
* implements processing resolve and unit test