### PR TITLE
Feature/6 process chargeback transactions

### DIFF
--- a/sample-tx.csv
+++ b/sample-tx.csv
@@ -2,9 +2,13 @@ type,client,tx,amount
 deposit,1,1,1.0
 deposit,2,2,2.0
 deposit,1,3,2.0
-deposit,3,3,2.4898
-withdrawal,1,4,1.5
-withdrawal,2,5,3.0
-withdrawal,1,5,0.3565
+deposit,3,4,2.4898
+withdrawal,1,5,1.5
+withdrawal,2,6,3.0
+withdrawal,1,7,0.3565
 dispute,1,1,0
 resolve,1,1,0
+chargeback,1,3,0
+deposit,1,8,2.0
+dispute,1,8,0
+chargeback,1,8,0

--- a/src/acct/account.rs
+++ b/src/acct/account.rs
@@ -54,6 +54,14 @@ impl Account {
             self.held -= tranx.amount;
         }
     }
+
+    pub fn chargeback(&mut self, tranx: &Transaction) {
+        if tranx.amount <= self.held {
+            self.held -= tranx.amount;
+            self.total -= tranx.amount;
+            self.locked = true;
+        }
+    }
 }
 
 pub fn print() {

--- a/src/acct/account.rs
+++ b/src/acct/account.rs
@@ -70,7 +70,7 @@ pub fn print() {
         storage::ACCOUNTS.lock().unwrap().reads(|iter| {
             for (_, acc) in iter {
                 csv_writer.serialize(acc).unwrap();
-                println!("{:?}", acc)
+                // println!("{:?}", acc)
             }
         })
     }
@@ -81,7 +81,16 @@ pub fn process_deposit(tranx: &Transaction) {
         return;
     }
 
-    insert_transaction(tranx);
+    let tx_exists: bool;
+
+    unsafe {
+        tx_exists = TxStore::TRANSACTIONS.lock().unwrap().exists(tranx.tx);
+    }
+
+    // handle duplicates
+    if tx_exists {
+        return;
+    }
 
     let account_exists: bool;
 
@@ -90,13 +99,23 @@ pub fn process_deposit(tranx: &Transaction) {
     }
 
     if !account_exists {
-        let new_account = Account::new(tranx.client, tranx.amount, 0.0);
+        let new_account = Account::new(tranx.client, 0.0, 0.0);
         unsafe {
             storage::ACCOUNTS.lock().unwrap().insert(new_account);
         }
-
-        return;
     }
+
+    unsafe {
+        let acct: Account = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx.client, |acct| acct.unwrap().clone());
+        // ignore if account is frozen
+        if acct.locked {
+            return;
+        }
+    }
+
     let u_account: Option<Account>;
 
     unsafe {
@@ -114,7 +133,15 @@ pub fn process_deposit(tranx: &Transaction) {
             });
 
         if let Some(acct) = u_account {
+            let new_tranx = Transaction::new(
+                tranx.r#type.to_string(),
+                tranx.client,
+                tranx.tx,
+                tranx.amount,
+            );
+
             storage::ACCOUNTS.lock().unwrap().insert(acct);
+            TxStore::TRANSACTIONS.lock().unwrap().insert(new_tranx);
         }
     }
 }
@@ -124,7 +151,16 @@ pub fn process_withdrawal(tranx: &Transaction) {
         return;
     }
 
-    insert_transaction(tranx);
+    let tx_exists: bool;
+
+    unsafe {
+        tx_exists = TxStore::TRANSACTIONS.lock().unwrap().exists(tranx.tx);
+    }
+
+    // handle duplicates
+    if tx_exists {
+        return;
+    }
 
     let account_exists: bool;
 
@@ -137,9 +173,19 @@ pub fn process_withdrawal(tranx: &Transaction) {
         unsafe {
             storage::ACCOUNTS.lock().unwrap().insert(new_account);
         }
-
-        return;
     }
+
+    unsafe {
+        let acct: Account = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx.client, |acct| acct.unwrap().clone());
+        // ignore if account is frozen
+        if acct.locked {
+            return;
+        }
+    }
+
     let u_account: Option<Account>;
 
     unsafe {
@@ -157,7 +203,15 @@ pub fn process_withdrawal(tranx: &Transaction) {
             });
 
         if let Some(acct) = u_account {
+            let new_tranx = Transaction::new(
+                tranx.r#type.to_string(),
+                tranx.client,
+                tranx.tx,
+                tranx.amount,
+            );
+
             storage::ACCOUNTS.lock().unwrap().insert(acct);
+            TxStore::TRANSACTIONS.lock().unwrap().insert(new_tranx);
         }
     }
 }
@@ -168,12 +222,17 @@ pub fn process_dispute(tranx: &Transaction) {
     }
 
     let tx_exists: bool;
+    let dispute_exists: bool;
 
     unsafe {
         tx_exists = TxStore::TRANSACTIONS.lock().unwrap().exists(tranx.tx);
+        dispute_exists = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute_exists(tranx.tx);
     }
 
-    if !tx_exists {
+    if !tx_exists || dispute_exists {
         return;
     }
 
@@ -184,14 +243,6 @@ pub fn process_dispute(tranx: &Transaction) {
             .lock()
             .unwrap()
             .read(tranx.tx, |trx| trx.unwrap().clone());
-
-        let dispute = Dispute::new(tranx.client, tranx.tx, false);
-
-        // Store dispute
-        TxStore::TRANSACTIONS
-            .lock()
-            .unwrap()
-            .insert_dispute(dispute);
     }
 
     let account_exists: bool;
@@ -210,6 +261,17 @@ pub fn process_dispute(tranx: &Transaction) {
     let u_account: Option<Account>;
 
     unsafe {
+        let acct: Account = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx.client, |acct| acct.unwrap().clone());
+        // ignore if account is frozen
+        if acct.locked {
+            return;
+        }
+    }
+
+    unsafe {
         u_account = storage::ACCOUNTS
             .lock()
             .unwrap()
@@ -224,7 +286,14 @@ pub fn process_dispute(tranx: &Transaction) {
             });
 
         if let Some(acct) = u_account {
+            let dispute = Dispute::new(tranx.client, tranx.tx, false);
+
             storage::ACCOUNTS.lock().unwrap().insert(acct);
+            // Store dispute
+            TxStore::TRANSACTIONS
+                .lock()
+                .unwrap()
+                .insert_dispute(dispute);
         }
     }
 }
@@ -281,6 +350,17 @@ pub fn process_resolve(tranx: &Transaction) {
         }
     }
 
+    unsafe {
+        let acct: Account = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx.client, |acct| acct.unwrap().clone());
+        // ignore if account is frozen
+        if acct.locked {
+            return;
+        }
+    }
+
     let u_account: Option<Account>;
 
     unsafe {
@@ -318,22 +398,102 @@ pub fn process_resolve(tranx: &Transaction) {
     }
 }
 
-fn insert_transaction(tranx: &Transaction) {
+pub fn process_chargeback(tranx: &Transaction) {
+    if tranx.r#type != "chargeback" {
+        return;
+    }
+
     let tx_exists: bool;
+    let dispute_exists: bool;
 
     unsafe {
         tx_exists = TxStore::TRANSACTIONS.lock().unwrap().exists(tranx.tx);
+        dispute_exists = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute_exists(tranx.tx);
     }
 
-    if !tx_exists {
-        let new_tranx = Transaction::new(
-            tranx.r#type.to_string(),
-            tranx.client,
-            tranx.tx,
-            tranx.amount,
-        );
+    if !tx_exists || !dispute_exists {
+        return;
+    }
+
+    let stored_tranx: Transaction;
+    let stored_dispute: Dispute;
+
+    unsafe {
+        stored_tranx = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .read(tranx.tx, |trx| trx.unwrap().clone());
+
+        stored_dispute = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute(tranx.tx, |trx| trx.unwrap().clone());
+    }
+
+    if stored_dispute.resolved {
+        return;
+    }
+
+    let account_exists: bool;
+
+    unsafe {
+        account_exists = storage::ACCOUNTS.lock().unwrap().exists(tranx.client);
+    }
+
+    if !account_exists {
+        let new_account = Account::new(tranx.client, 0.0, 0.0);
         unsafe {
-            TxStore::TRANSACTIONS.lock().unwrap().insert(new_tranx);
+            storage::ACCOUNTS.lock().unwrap().insert(new_account);
+        }
+    }
+
+    unsafe {
+        let acct: Account = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx.client, |acct| acct.unwrap().clone());
+        // ignore if account is frozen
+        if acct.locked {
+            return;
+        }
+    }
+
+    let u_account: Option<Account>;
+
+    unsafe {
+        let updated_dispute =
+            TxStore::TRANSACTIONS
+                .lock()
+                .unwrap()
+                .modify_dispute(stored_dispute.tx, |dis| {
+                    let disp = dis.unwrap();
+                    disp.resolved = true;
+
+                    return *disp;
+                });
+
+        u_account = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .modify(tranx.client, |acct| {
+                let a = if let Some(acc) = acct {
+                    acc.chargeback(&stored_tranx);
+                    Some(*acc)
+                } else {
+                    None
+                };
+                return a;
+            });
+
+        if let Some(acct) = u_account {
+            storage::ACCOUNTS.lock().unwrap().insert(acct);
+            TxStore::TRANSACTIONS
+                .lock()
+                .unwrap()
+                .insert_dispute(updated_dispute);
         }
     }
 }

--- a/src/acct/tests.rs
+++ b/src/acct/tests.rs
@@ -372,6 +372,20 @@ fn test_account_deposit() {
         account.total
     );
 
+    assert!(
+        account.held == 0.0,
+        "wrong held funds; expect {}, got {}",
+        0.0,
+        account.held
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
     account.deposit(&tranx);
 
     // Test deposited funds
@@ -387,6 +401,20 @@ fn test_account_deposit() {
         "wrong total funds; expect {}, got {}",
         35.0,
         account.total
+    );
+
+    assert!(
+        account.held == 0.0,
+        "wrong held funds; expect {}, got {}",
+        0.0,
+        account.held
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
     );
 }
 
@@ -415,6 +443,20 @@ fn test_account_withdraw() {
         account.total
     );
 
+    assert!(
+        account.held == 0.0,
+        "wrong held funds; expect {}, got {}",
+        0.0,
+        account.held
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
     // Test withdrawing excess funds
 
     tranx.amount = 50.0;
@@ -435,6 +477,20 @@ fn test_account_withdraw() {
         account.total
     );
 
+    assert!(
+        account.held == 0.0,
+        "wrong held funds; expect {}, got {}",
+        0.0,
+        account.held
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
     // Test withdrawn funds
 
     tranx.amount = 5.0;
@@ -452,6 +508,20 @@ fn test_account_withdraw() {
         "wrong total funds; expect {}, got {}",
         15.0,
         account.total
+    );
+
+    assert!(
+        account.held == 0.0,
+        "wrong held funds; expect {}, got {}",
+        0.0,
+        account.held
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
     );
 }
 
@@ -480,6 +550,20 @@ fn test_account_dispute() {
         account.held
     );
 
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
     // Test disputing excess funds
 
     tranx.amount = 50.0;
@@ -500,6 +584,20 @@ fn test_account_dispute() {
         account.held
     );
 
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
     // Test disputing funds
 
     tranx.amount = 15.0;
@@ -517,6 +615,20 @@ fn test_account_dispute() {
         "wrong held funds; expect {}, got {}",
         15.0,
         account.held
+    );
+
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
     );
 }
 
@@ -540,6 +652,20 @@ fn test_account_resolve() {
         account.held
     );
 
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
     // Test resolving excess funds
 
     tranx_deposit.amount = 50.0;
@@ -560,6 +686,20 @@ fn test_account_resolve() {
         account.held
     );
 
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
     // Test resolving funds
 
     tranx_deposit.amount = 20.0;
@@ -577,5 +717,121 @@ fn test_account_resolve() {
         "wrong held funds; expect {}, got {}",
         0.0,
         account.held
+    );
+
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+}
+
+#[test]
+fn test_account_chargeback() {
+    let mut account = Account::new(1, 0.0, 20.0);
+    let mut tranx_deposit = Transaction::new("deposit".to_string(), 1, 1, 20.0);
+
+    // Test initial funds
+    assert!(
+        account.available == 0.0,
+        "wrong available funds; expect {}, got {}",
+        0.0,
+        account.available
+    );
+
+    assert!(
+        account.held == 20.0,
+        "wrong held funds; expect {}, got {}",
+        20.0,
+        account.held
+    );
+
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
+    // Test resolving excess funds
+
+    tranx_deposit.amount = 50.0;
+
+    account.chargeback(&tranx_deposit);
+
+    assert!(
+        account.available == 0.0,
+        "wrong available funds; expect {}, got {}",
+        0.0,
+        account.available
+    );
+
+    assert!(
+        account.held == 20.0,
+        "wrong held funds; expect {}, got {}",
+        20.0,
+        account.held
+    );
+
+    assert!(
+        account.total == 20.0,
+        "wrong total funds; expect {}, got {}",
+        20.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == false,
+        "wrong locked status; expect {}, got {}",
+        false,
+        account.locked
+    );
+
+    // Test resolving funds
+
+    tranx_deposit.amount = 20.0;
+    account.chargeback(&tranx_deposit);
+
+    assert!(
+        account.available == 0.0,
+        "wrong available funds; expect {}, got {}",
+        0.0,
+        account.available
+    );
+
+    assert!(
+        account.held == 0.0,
+        "wrong held funds; expect {}, got {}",
+        0.0,
+        account.held
+    );
+
+    assert!(
+        account.total == 0.0,
+        "wrong total funds; expect {}, got {}",
+        0.0,
+        account.total
+    );
+
+    assert!(
+        account.locked == true,
+        "wrong locked status; expect {}, got {}",
+        true,
+        account.locked
     );
 }

--- a/src/acct/tests.rs
+++ b/src/acct/tests.rs
@@ -16,7 +16,7 @@ fn test_process_deposit() {
     let tranx_2 = Transaction {
         r#type: "deposit".to_string(),
         client: 1,
-        tx: 1,
+        tx: 11,
         amount: 15.0,
     };
 
@@ -41,6 +41,27 @@ fn test_process_deposit() {
         );
 
         assert!(
+            acct.held == 0.0,
+            "invalid held funds; expected {}, got {}",
+            0.0,
+            acct.total
+        );
+
+        assert!(
+            acct.total == tranx_1.amount,
+            "invalid total funds; expected {}, got {}",
+            tranx_1.amount,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
+        );
+
+        assert!(
             tranx.r#type == tranx_1.r#type,
             "invalid transaction type funds; expected {}, got {}",
             tranx_1.r#type,
@@ -70,38 +91,95 @@ fn test_process_deposit() {
             .unwrap()
             .read(tranx_2.client, |acc| acc.unwrap().clone());
 
+        let tranx = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .read(tranx_2.tx, |tranx| tranx.unwrap().clone());
+
+        let available = tranx_1.amount + tranx_2.amount;
+
         assert!(
-            acct.available == (tranx_1.amount + tranx_2.amount),
+            acct.available == available,
             "invalid available funds; expected {}, got {}",
-            tranx_1.amount,
+            available,
             acct.available
+        );
+
+        assert!(
+            acct.held == 0.0,
+            "invalid held funds; expected {}, got {}",
+            0.0,
+            acct.total
+        );
+
+        assert!(
+            acct.total == available,
+            "invalid total funds; expected {}, got {}",
+            available,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
+        );
+
+        assert!(
+            tranx.r#type == tranx_2.r#type,
+            "invalid transaction type funds; expected {}, got {}",
+            tranx_2.r#type,
+            tranx.r#type
+        );
+
+        assert!(
+            tranx.amount == tranx_2.amount,
+            "invalid transaction amount funds; expected {}, got {}",
+            tranx_2.amount,
+            tranx.amount
+        );
+
+        assert!(
+            tranx.client == tranx_2.client,
+            "invalid transaction client funds; expected {}, got {}",
+            tranx_2.client,
+            tranx.client
         );
     }
 }
 
 #[test]
 fn test_process_withdrawal() {
-    let tranx_1 = Transaction {
+    let client = 2;
+    let tranx_withdrawal = Transaction {
         r#type: "withdrawal".to_string(),
-        client: 2,
+        client,
         tx: 2,
         amount: 10.0,
     };
 
-    let tranx_2 = Transaction {
+    let tranx_withdrawal_2 = Transaction {
+        r#type: "withdrawal".to_string(),
+        client,
+        tx: 22,
+        amount: 10.0,
+    };
+
+    let tranx_deposit = Transaction {
         r#type: "deposit".to_string(),
-        client: 2,
-        tx: 2,
+        client,
+        tx: 222,
         amount: 15.0,
     };
 
-    account::process_withdrawal(&tranx_1);
+    account::process_withdrawal(&tranx_withdrawal);
 
     unsafe {
         let acct = storage::ACCOUNTS
             .lock()
             .unwrap()
-            .read(tranx_1.client, |acc| acc.unwrap().clone());
+            .read(client, |acc| acc.unwrap().clone());
 
         assert!(
             acct.available == 0.0,
@@ -110,47 +188,89 @@ fn test_process_withdrawal() {
             acct.available
         );
 
+        assert!(
+            acct.held == 0.0,
+            "invalid held funds; expected {}, got {}",
+            0.0,
+            acct.total
+        );
+
+        assert!(
+            acct.total == 0.0,
+            "invalid total funds; expected {}, got {}",
+            0.0,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
+        );
+
         let tranx = TxStore::TRANSACTIONS
             .lock()
             .unwrap()
-            .read(tranx_1.tx, |tranx| tranx.unwrap().clone());
+            .read(tranx_withdrawal.tx, |tranx| tranx.unwrap().clone());
 
         assert!(
-            tranx.r#type == tranx_1.r#type,
+            tranx.r#type == tranx_withdrawal.r#type,
             "invalid transaction type funds; expected {}, got {}",
-            tranx_1.r#type,
+            tranx_withdrawal.r#type,
             tranx.r#type
         );
 
         assert!(
-            tranx.amount == tranx_1.amount,
+            tranx.amount == tranx_withdrawal.amount,
             "invalid transaction amount funds; expected {}, got {}",
-            tranx_1.amount,
+            tranx_withdrawal.amount,
             tranx.amount
         );
 
         assert!(
-            tranx.client == tranx_1.client,
+            tranx.client == tranx_withdrawal.client,
             "invalid transaction client funds; expected {}, got {}",
-            tranx_1.client,
+            tranx_withdrawal.client,
             tranx.client
         );
     }
 
-    account::process_deposit(&tranx_2);
-    account::process_withdrawal(&tranx_1);
+    account::process_deposit(&tranx_deposit);
+    account::process_withdrawal(&tranx_withdrawal_2);
 
     unsafe {
         let acct = storage::ACCOUNTS
             .lock()
             .unwrap()
-            .read(tranx_2.client, |acc| acc.unwrap().clone());
-        let amount_diff = tranx_2.amount - tranx_1.amount;
+            .read(client, |acc| acc.unwrap().clone());
+        let amount_diff = tranx_deposit.amount - tranx_withdrawal_2.amount;
         assert!(
             acct.available == amount_diff,
             "invalid available funds; expected {}, got {}",
             amount_diff,
             acct.available
+        );
+
+        assert!(
+            acct.held == 0.0,
+            "invalid held funds; expected {}, got {}",
+            0.0,
+            acct.total
+        );
+
+        assert!(
+            acct.total == amount_diff,
+            "invalid total funds; expected {}, got {}",
+            amount_diff,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
         );
     }
 }
@@ -199,6 +319,21 @@ fn test_process_dispute() {
             "invalid held funds; expected {}, got {}",
             tranx_deposit_2.amount,
             acct.held
+        );
+
+        let total = tranx_deposit.amount + tranx_deposit_2.amount;
+        assert!(
+            acct.total == total,
+            "invalid total funds; expected {}, got {}",
+            total,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
         );
 
         let dispute = TxStore::TRANSACTIONS
@@ -269,6 +404,21 @@ fn test_process_resolve() {
             acct.held
         );
 
+        let total = tranx_deposit.amount + tranx_deposit_2.amount;
+        assert!(
+            acct.total == total,
+            "invalid total funds; expected {}, got {}",
+            total,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
+        );
+
         let dispute = TxStore::TRANSACTIONS
             .lock()
             .unwrap()
@@ -317,6 +467,175 @@ fn test_process_resolve() {
             "invalid held funds; expected {}, got {}",
             0.0,
             acct.held
+        );
+
+        let total = tranx_deposit.amount + tranx_deposit_2.amount;
+        assert!(
+            acct.total == total,
+            "invalid total funds; expected {}, got {}",
+            total,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
+        );
+
+        let dispute = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute(tranx_dispute.tx, |acc| acc.unwrap().clone());
+
+        assert!(
+            dispute.tx == tranx_dispute.tx,
+            "invalid dispute tx; expected {}, got {}",
+            tranx_dispute.tx,
+            dispute.tx
+        );
+
+        assert!(
+            dispute.client == tranx_dispute.client,
+            "invalid dispute client; expected {}, got {}",
+            tranx_dispute.client,
+            dispute.client
+        );
+
+        assert!(
+            dispute.resolved == true,
+            "invalid dispute client; expected {}, got {}",
+            true,
+            dispute.resolved
+        );
+    }
+}
+
+#[test]
+fn test_process_chargeback() {
+    let tranx_dispute = Transaction::new("dispute".to_string(), 5, 55, 0.0);
+    let tranx_chargeback = Transaction::new("chargeback".to_string(), 5, 55, 0.0);
+
+    let tranx_deposit = Transaction::new("deposit".to_string(), 5, 5, 15.0);
+    let tranx_deposit_2 = Transaction::new("deposit".to_string(), 5, 55, 10.0);
+
+    // test not existing dispute
+    account::process_chargeback(&tranx_chargeback);
+
+    unsafe {
+        storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx_dispute.client, |acc| {
+                assert!(
+                    acc == None,
+                    "invalid available funds; expected {}, got {:?}",
+                    "None",
+                    acc
+                );
+            });
+    }
+
+    account::process_deposit(&tranx_deposit);
+    account::process_deposit(&tranx_deposit_2);
+    account::process_dispute(&tranx_dispute);
+
+    unsafe {
+        let acct = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx_dispute.client, |acc| acc.unwrap().clone());
+        assert!(
+            acct.available == tranx_deposit.amount,
+            "invalid available funds; expected {}, got {}",
+            tranx_deposit.amount,
+            acct.available
+        );
+
+        assert!(
+            acct.held == tranx_deposit_2.amount,
+            "invalid held funds; expected {}, got {}",
+            tranx_deposit_2.amount,
+            acct.held
+        );
+
+        let total = tranx_deposit.amount + tranx_deposit_2.amount;
+        assert!(
+            acct.total == total,
+            "invalid total funds; expected {}, got {}",
+            total,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == false,
+            "wrong locked status; expect {}, got {}",
+            false,
+            acct.locked
+        );
+
+        let dispute = TxStore::TRANSACTIONS
+            .lock()
+            .unwrap()
+            .dispute(tranx_dispute.tx, |acc| acc.unwrap().clone());
+
+        assert!(
+            dispute.tx == tranx_dispute.tx,
+            "invalid dispute tx; expected {}, got {}",
+            tranx_dispute.tx,
+            dispute.tx
+        );
+
+        assert!(
+            dispute.client == tranx_dispute.client,
+            "invalid dispute client; expected {}, got {}",
+            tranx_dispute.client,
+            dispute.client
+        );
+
+        assert!(
+            dispute.resolved == false,
+            "invalid dispute client; expected {}, got {}",
+            false,
+            dispute.resolved
+        );
+    }
+    // test chargeback
+    account::process_chargeback(&tranx_chargeback);
+
+    unsafe {
+        let acct = storage::ACCOUNTS
+            .lock()
+            .unwrap()
+            .read(tranx_dispute.client, |acc| acc.unwrap().clone());
+
+        assert!(
+            acct.available == tranx_deposit.amount,
+            "invalid available funds; expected {}, got {}",
+            tranx_deposit.amount,
+            acct.available
+        );
+
+        assert!(
+            acct.held == 0.0,
+            "invalid held funds; expected {}, got {}",
+            0.0,
+            acct.held
+        );
+
+        assert!(
+            acct.total == tranx_deposit.amount,
+            "invalid total funds; expected {}, got {}",
+            tranx_deposit_2.amount,
+            acct.total
+        );
+
+        assert!(
+            acct.locked == true,
+            "wrong locked status; expect {}, got {}",
+            true,
+            acct.locked
         );
 
         let dispute = TxStore::TRANSACTIONS

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn read_csv_file() -> Result<(), Box<dyn Error>> {
         account::process_withdrawal(&record);
         account::process_dispute(&record);
         account::process_resolve(&record);
+        account::process_chargeback(&record);
     }
 
     account::print();

--- a/src/tx/storage.rs
+++ b/src/tx/storage.rs
@@ -81,11 +81,11 @@ impl TransactionStorage {
     }
 
     pub fn dispute_exists(&self, id: u32) -> bool {
-        self.transactions.lock().unwrap().contains_key(&id)
+        self.disputes.lock().unwrap().contains_key(&id)
     }
 
     pub fn clear_disputes(&self) {
-        self.transactions.lock().unwrap().clear();
+        self.disputes.lock().unwrap().clear();
     }
 }
 


### PR DESCRIPTION
Task:
1. Add a method that handles chargebacks.
2. Ignore if:
 * transaction does not exist.
 * transaction is not under dispute.
 *  if tx amount is greater than held funds
3. Decrease held and total funds of the client by the amount no longer in dispute.
4. The client account should be frozen (locked) if chargeback occurs.

Commits:
* added chargeback method to account and unit tests
* implements processing chargebacks and unit test